### PR TITLE
Update OAuth2Service.cs changing "scope=" to "scopes="

### DIFF
--- a/ApiClient/OAuth2/OAuth2Service.cs
+++ b/ApiClient/OAuth2/OAuth2Service.cs
@@ -54,7 +54,7 @@ namespace ApiClient.OAuth2
         /// <returns>String which is the oauth2 authorization url.</returns>
         public string GenerateAuthUrl(string scopes = "", string state = null)
         {
-            var url = string.Format("{0}?client_id={1}&scope={2}&redirect_uri={3}&response_type={4}",
+            var url = string.Format("{0}?client_id={1}&scopes={2}&redirect_uri={3}&response_type={4}",
                                     DigiKeyUriConstants.AuthorizationEndpoint,
                                     ClientSettings.ClientId,
                                     scopes,


### PR DESCRIPTION
"scope" should be "scopes". "scope=" in the generated url prevented sandbox-api from generating an authentication page, instead producing a blank page.  This is intended to resolve issue #7 